### PR TITLE
Update config.json

### DIFF
--- a/hassio-hotspot/config.json
+++ b/hassio-hotspot/config.json
@@ -25,6 +25,7 @@
     "config:rw",
     "ssl:rw"
   ],
+  "init": false,
   "options": {
     "ssid": "",
     "wpa_passphrase": "",


### PR DESCRIPTION
Fix s6-overlay-suexec: fatal: can only run as pid 1 home assistant 2022.5  https://developers.home-assistant.io/blog/2022/05/12/s6-overlay-base-images/