### PR TITLE
Networkmanager cli

### DIFF
--- a/hassio-hotspot/CHANGELOG.md
+++ b/hassio-hotspot/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.1.6]
+### Fixed
+- Add switch from networkmanager to networkmanager-cli for nmcli (thanks to @dfries)
+
 ## [1.1.5]
 ### Fixed
 - Fix missmatched interface name (thanks to @smbitech)

--- a/hassio-hotspot/Dockerfile
+++ b/hassio-hotspot/Dockerfile
@@ -13,7 +13,7 @@ RUN apk update && apk add --no-cache    \
     avahi                               \
     bash jq iw net-tools                \
     sudo busybox-extras                 \
-    hostapd networkmanager iptables     \
+    hostapd networkmanager-cli iptables \
     linux-firmware-other                \
     linux-firmware-ath6k                \
     linux-firmware-ath10k               \

--- a/hassio-hotspot/README.md
+++ b/hassio-hotspot/README.md
@@ -1,7 +1,7 @@
 # hassio-hotspot (previously hassio-hostapd-extended)
-Enables an access point using USB Wifi dongle for your IoT devies on Home Assistant (with embedded DHCP server). This is mostly usefull if you want to have a different network infrastructure for your IoT devices, and can not do it with the RPi onboard Wifi, due to stabilities issue. 
+Enables an access point using USB WiFi dongle (or onboard) for your IoT devies on Home Assistant (with embedded DHCP server). USB WiFi is mostly useful if you want to have a different network infrastructure for your IoT devices, and the RPI onboard WiFi is not available or is unstable.
 
-It allows creating an access point **with optional a DHCP server**, to your IoT devices using extenral USB Wifi dongles, **Ralink, Atheros and others**. It began a fork of the hostapd addon, that I renamed, given that it now does more than that: it adds DHCP server with selectable internet access to the devices on the hotspot. It also adds supports to external USB dongles in order to enable a stable access points, known that the onboard Broadcomm Wifi on the RPi has unstable operation and does not provide the reliability required.
+It allows creating an access point **with optional a DHCP server**, to your IoT devices using external USB WiFi dongles, **Ralink, Atheros and others**. It began a fork of the hostapd addon, that I renamed, given that it now does more than that: it adds DHCP server with selectable internet access to the devices on the hotspot. It also adds supports to external USB dongles in order to enable a stable access points, known that the onboard Broadcomm WiFi on the RPI has unstable operation and does not provide the reliability required.
 
 ## Installation
 

--- a/hassio-hotspot/config.json
+++ b/hassio-hotspot/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Hassio Hotspot",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "slug": "hassio-hotspot",
   "description": "Access point for your IoT devives with configurable network interface and DHCP server",
   "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],

--- a/linux-router/Dockerfile
+++ b/linux-router/Dockerfile
@@ -12,7 +12,7 @@ ENV LANG C.UTF-8
 RUN apk update && apk add --no-cache    \
     bash jq                             \
     busybox-extras                      \
-    hostapd networkmanager iptables     \
+    hostapd networkmanager-cli iptables \
     procps-ng iw dnsmasq net-tools      \
     linux-firmware-other                \
     linux-firmware-ath6k                \


### PR DESCRIPTION
With the Home Assistant operating system 12.3, and Core 2024.6.2 installing this resulted in an error that nmcli was not found.  I'm guessing the networkmanager was split up and nmcli is now only in networkmanager-cli so I updated it.

Unfortunately with this change I'm getting the following warning in the log, I did not specify the version, otherwise it will need to be updated every time  Home Assistant changes it's version.

```
Warning: nmcli (1.46.0) and NetworkManager (1.44.2) versions don't match. Restarting NetworkManager is advised.
```

Thanks for this package, it was just what I wanted.  My Raspberry Pi is on a wired network, I was looking for something to enable the Raspberry Pi to be  an access point so my WiFi IoT devices could be directly connected to the RPI.