### PR TITLE
Linux Router: Add configurable LAN access and fix channel selection for hotspot

### DIFF
--- a/linux-router/CHANGELOG.md
+++ b/linux-router/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## [1.0.3]
-- Add option to configure LAN access.
+- Add option to configure LAN access
+- Fix channel configuration not working
 
 ## [1.0.2]
 - Implement fix to user_args not being passed correctly (thanks to @vak-git)

--- a/linux-router/CHANGELOG.md
+++ b/linux-router/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [1.0.3]
+- Add option to configure LAN access.
+
 ## [1.0.2]
 - Implement fix to user_args not being passed correctly (thanks to @vak-git)
 

--- a/linux-router/config.json
+++ b/linux-router/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Linux Router",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "slug": "linux-router",
   "description": "Access point for your IoT devives with configurable network interface, DHCP server and much more",
   "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],

--- a/linux-router/config.json
+++ b/linux-router/config.json
@@ -33,8 +33,8 @@
     "address": "192.168.2.1",
     "interface": "",
     "allow_internet": false,
-    "hide_ssid": false,
-    "ban_priv": false,  
+    "allow_lan": "bool",
+    "hide_ssid": false,  
     "user_args": ""
   },
   "schema": {
@@ -44,8 +44,8 @@
     "address": "str",
     "interface": "str",
     "allow_internet": "bool",
+    "allow_lan": "bool",
     "hide_ssid": "bool",
-    "ban_priv": "bool",
     "user_args": "str"
   }
 }

--- a/linux-router/config.json
+++ b/linux-router/config.json
@@ -34,6 +34,7 @@
     "interface": "",
     "allow_internet": false,
     "hide_ssid": false,
+    "ban_priv": false,  
     "user_args": ""
   },
   "schema": {
@@ -44,6 +45,7 @@
     "interface": "str",
     "allow_internet": "bool",
     "hide_ssid": "bool",
+    "ban_priv": "bool",
     "user_args": "str"
   }
 }

--- a/linux-router/config.json
+++ b/linux-router/config.json
@@ -33,7 +33,7 @@
     "address": "192.168.2.1",
     "interface": "",
     "allow_internet": false,
-    "allow_lan": "bool",
+    "allow_lan": false,
     "hide_ssid": false,  
     "user_args": ""
   },

--- a/linux-router/run.sh
+++ b/linux-router/run.sh
@@ -67,12 +67,12 @@ if [[ ${ALLOW_INTERNET} = false ]]; then
     EXTRA_ARGS+="-n "
 fi
 
-if [[ ${HIDE_SSID} = true ]]; then
-    EXTRA_ARGS+="--hidden "
-fi
-
 if [[ ${BAN_PRIV} == false ]]; then
     EXTRA_ARGS+="--ban-priv "
+fi
+
+if [[ ${HIDE_SSID} = true ]]; then
+    EXTRA_ARGS+="--hidden "
 fi
 
 EXTRA_ARGS+="-g ${ADDRESS} "

--- a/linux-router/run.sh
+++ b/linux-router/run.sh
@@ -19,8 +19,8 @@ CHANNEL=$(jq --raw-output ".channel" $CONFIG_PATH)
 ADDRESS=$(jq --raw-output ".address" $CONFIG_PATH)
 INTERFACE=$(jq --raw-output ".interface" $CONFIG_PATH)
 ALLOW_INTERNET=$(jq --raw-output ".allow_internet" $CONFIG_PATH)
+BAN_PRIV=$(jq --raw-output ".allow_lan" $CONFIG_PATH)
 HIDE_SSID=$(jq --raw-output ".hide_ssid" $CONFIG_PATH)
-BAN_PRIV=$(jq --raw-output ".ban_priv" $CONFIG_PATH)
 USER_ARGS=$(jq --raw-output ".user_args" $CONFIG_PATH)
 
 
@@ -71,7 +71,7 @@ if [[ ${HIDE_SSID} = true ]]; then
     EXTRA_ARGS+="--hidden "
 fi
 
-if [[ ${BAN_PRIV} == true ]]; then
+if [[ ${BAN_PRIV} == false ]]; then
     EXTRA_ARGS+="--ban-priv "
 fi
 

--- a/linux-router/run.sh
+++ b/linux-router/run.sh
@@ -20,6 +20,7 @@ ADDRESS=$(jq --raw-output ".address" $CONFIG_PATH)
 INTERFACE=$(jq --raw-output ".interface" $CONFIG_PATH)
 ALLOW_INTERNET=$(jq --raw-output ".allow_internet" $CONFIG_PATH)
 HIDE_SSID=$(jq --raw-output ".hide_ssid" $CONFIG_PATH)
+BAN_PRIV=$(jq --raw-output ".ban_priv" $CONFIG_PATH)
 USER_ARGS=$(jq --raw-output ".user_args" $CONFIG_PATH)
 
 
@@ -68,6 +69,10 @@ fi
 
 if [[ ${HIDE_SSID} = true ]]; then
     EXTRA_ARGS+="--hidden "
+fi
+
+if [[ ${BAN_PRIV} == true ]]; then
+    EXTRA_ARGS+="--ban-priv "
 fi
 
 EXTRA_ARGS+="-g ${ADDRESS} "

--- a/linux-router/run.sh
+++ b/linux-router/run.sh
@@ -70,7 +70,6 @@ if [[ ${HIDE_SSID} = true ]]; then
     EXTRA_ARGS+="--hidden "
 fi
 
-EXTRA_ARGS+="--ban-priv "
 EXTRA_ARGS+="-g ${ADDRESS} "
 
 ./lnxrouter --ap ${INTERFACE} ${SSID} --password ${PASSPHRASE} ${EXTRA_ARGS} ${USER_ARGS}

--- a/linux-router/run.sh
+++ b/linux-router/run.sh
@@ -63,6 +63,10 @@ echo "Network interface set to ${INTERFACE}"
 
 EXTRA_ARGS=""
 
+if [[ "$CHANNEL" -gt 0 ]]; then
+    EXTRA_ARGS+="-c ${CHANNEL} "
+fi
+
 if [[ ${ALLOW_INTERNET} = false ]]; then
     EXTRA_ARGS+="-n "
 fi


### PR DESCRIPTION
Added a configuration option (allow_lan) to enable or disable LAN access for connected devices.
Resolved issue where specifying a channel in the configuration was ignored.